### PR TITLE
fix: improve allow failure functionality

### DIFF
--- a/call.go
+++ b/call.go
@@ -39,13 +39,14 @@ func ParseABI(rawJson string) (*abi.ABI, error) {
 
 // Call wraps a multicall call.
 type Call struct {
-	CallName string
-	Contract *Contract
-	Method   string
-	Inputs   []any
-	Outputs  any
-	CanFail  bool
-	Failed   bool
+	CallName    string
+	Contract    *Contract
+	Method      string
+	Inputs      []any
+	Outputs     any
+	CanFail     bool
+	Failed      bool
+	UnpackError error
 }
 
 // NewCall creates a new call using given inputs.

--- a/caller.go
+++ b/caller.go
@@ -68,10 +68,10 @@ func (caller *Caller) Call(opts *bind.CallOpts, calls ...*Call) ([]*Call, error)
 
 	for i, result := range results {
 		call := calls[i] // index always matches
-		call.Failed = !result.Success
 		if err := call.Unpack(result.ReturnData); err != nil {
-			return calls, fmt.Errorf("failed to unpack call outputs at index [%d]: %v", i, err)
+			call.UnpackError = fmt.Errorf("failed to unpack call outputs at index [%d]: %v", i, err)
 		}
+		call.Failed = !result.Success || err != nil
 	}
 
 	return calls, nil


### PR DESCRIPTION
The goal here is to allow unpacking of calls even if one of them fails because this contradicts with the functionality of `AllowFailure`. What happens here is even if the subsequent calls are fine, and say only one preceding call if faulty all the remaining calls suffer with no result because of the return statement in the error check.

I propose to have an unpacking error associated with the call itself and setting the boolean based on the unpack and the call to the blockchain. If this behaviour was already discussed/thought on, please let me know the intention behind it :) @canercidam